### PR TITLE
platform.ini fixes to get all targets to build

### DIFF
--- a/ESP32-WiFi-Hash-Monster/ESP32-WiFi-Hash-Monster.ino
+++ b/ESP32-WiFi-Hash-Monster/ESP32-WiFi-Hash-Monster.ino
@@ -23,11 +23,19 @@
 // Button : click to change channel hold to dis/enable SD
 // SD : GPIO4=CS(CD/D3), 23=MOSI(CMD), 18=CLK, 19=MISO(D0)
 //--------------------------------------------------------------------
-//#include <M5Core2.h>        // https://github.com/m5stack/M5Core2/
-//#include <M5Stack.h>        // https://github.com/m5stack/M5Stack/    (use version => 0.3.0 to properly display the Monster)
-#include <ESP32-Chimera-Core.h>        // https://github.com/tobozo/ESP32-Chimera-Core/
+#ifdef ARDUINO_M5STACK_Core2
+  #include <M5Core2.h>        // https://github.com/m5stack/M5Core2/
+#endif
+#if defined(ARDUINO_M5STACK_FIRE) || defined(ARDUINO_M5Stack_Core_ESP32)
+  #include <M5Stack.h>        // https://github.com/m5stack/M5Stack/    (use version => 0.3.0 to properly display the Monster)
+#endif
+#ifdef ARDUINO_ODROID_ESP32
+  #include <ESP32-Chimera-Core.h>        // https://github.com/tobozo/ESP32-Chimera-Core/
+#endif
 
+#ifdef USE_M5STACK_UPDATER
 #include <M5StackUpdater.h> // https://github.com/tobozo/M5Stack-SD-Updater/
+#endif
 #include "Free_Fonts.h"
 #include <SPI.h>
 #include "freertos/FreeRTOS.h"
@@ -177,8 +185,10 @@ void setup() {
     FastLED.show();
   #endif
   M5.begin(); // this will fire Serial.begin()
+  #ifdef USE_M5STACK_UPDATER
   // New SD Updater support, requires the latest version of https://github.com/tobozo/M5Stack-SD-Updater/
   checkSDUpdater( /*SD, MENU_BIN, 1500*/ ); // Filesystem, Launcher bin path, Wait delay
+  #endif
   // SD card ---------------------------------------------------------
   bool toggle = false;
   unsigned long lastcheck = millis();
@@ -194,7 +204,7 @@ void setup() {
       #ifdef ARDUINO_M5STACK_Core2
         M5.Axp.SetLcdVoltage(2500);
         M5.Axp.DeepSleep();
-      #else
+      #elif defined(ARDUINO_M5STACK_FIRE) || defined(ARDUINO_M5Stack_Core_ESP32)
         M5.setWakeupButton( BUTTON_B_PIN );
         M5.powerOFF();
       #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,20 +11,19 @@
 
 [platformio]
 src_dir = ESP32-WiFi-Hash-Monster
+default_envs = m5stack-fire
+;default_envs = m5stack-core-esp32
+;default_envs = m5stack-core2
+;default_envs = odroid_esp32
 
-
-[env:m5stack-core-esp32]
+[env]
 platform = espressif32
-board = m5stack-fire ;This can be one of m5stack-fire, odroid_esp32, m5stack-core-esp32 or m5stack-core2
 framework = arduino
 upload_speed = 921600
-
-
+; deep needed in order to pick up SD.h dependency of M5Stack-SD-Updater
+lib_ldf_mode = deep
 ; lib_extra_dirs = ~/Documents/Arduino/libraries/
-lib_ldf_mode = chain+
 lib_deps =
-  M5Stack
-  M5Stack-SD-Updater
   Wire
   SPI
   FS
@@ -37,5 +36,34 @@ lib_deps =
   Preferences
   FastLED
 
-; Warning upstream M5Stack-SD-Updater fails including SD.h 
-; Had to manually add #include <SD.h>. lib_ldf_mode = chain+ didn't help
+[env:m5stack-fire]
+board = m5stack-fire
+lib_deps =
+  ${env.lib_deps}
+  M5Stack
+  M5Stack-SD-Updater
+build_flags =
+  '-DUSE_M5STACK_UPDATER'
+
+[env:m5stack-core-esp32]
+board = m5stack-core-esp32
+lib_deps =
+  ${env.lib_deps}
+  M5Stack
+  M5Stack-SD-Updater
+build_flags =
+  '-DUSE_M5STACK_UPDATER'
+
+[env:m5stack-core2]
+board = m5stack-core2
+lib_deps =
+  ${env.lib_deps}
+  M5Core2
+lib_ignore =
+  M5Stack
+
+[env:odroid_esp32]
+board = odroid_esp32
+lib_deps =
+  ${env.lib_deps}
+  ESP32-Chimera-Core


### PR DESCRIPTION
I don't have all 4 target boards (only M5Stack Fire), but I can say they at least all build now.  No edits to the source are needed anymore: you only have to change one line in platform.ini.

I changed lib_ldf_mode from chain+ to deep, as this seems to fix the SD.h error from M5Stack-SD-Updater.