### PR TITLE
Buffer: fixed microseconds rollover

### DIFF
--- a/ESP32-WiFi-Hash-Monster/Buffer.h
+++ b/ESP32-WiFi-Hash-Monster/Buffer.h
@@ -28,6 +28,8 @@ class Buffer {
     void write(uint16_t n);
     void write(uint8_t* buf, uint32_t len);
 
+    uint64_t micros64();
+
     uint8_t* bufA;
     uint8_t* bufB;
 
@@ -42,6 +44,9 @@ class Buffer {
     const char *folderName = "/pcap"; // no trailing slash
     const char *fileNameTpl = "%s/%04X.pcap"; // hex is better for natural sorting, assume max 65536 files
     File file;
+
+    uint32_t previous_micros = 0;
+    uint32_t micros_high = 0;
 };
 
 #endif


### PR DESCRIPTION
Microseconds overflows every (2^31 / 1e6) = 2147 seconds.  This is fixed by using a 64-bit timer and keeping track of rollover.