### PR TITLE
Add default monitor_speed to plaftormio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ default_envs = m5stack-fire
 platform = espressif32
 framework = arduino
 upload_speed = 921600
+monitor_speed = 115200
 ; deep needed in order to pick up SD.h dependency of M5Stack-SD-Updater
 lib_ldf_mode = deep
 ; lib_extra_dirs = ~/Documents/Arduino/libraries/


### PR DESCRIPTION
Added default monitor_speed to plaftormio.ini to enable the use without any issue of the PlatformIO Serial Monitor shortcut.