### PR TITLE
Misc fixes

### DIFF
--- a/ESP32-WiFi-Hash-Monster/Buffer.cpp
+++ b/ESP32-WiFi-Hash-Monster/Buffer.cpp
@@ -1,18 +1,25 @@
 #include "Buffer.h"
 
 Buffer::Buffer() {
-  bufA = (uint8_t*)malloc(BUF_SIZE);
-  if( bufA == NULL ) {
-    log_e("Panic! Can't malloc %d bytes for buffer 1", BUF_SIZE );
-    while(1) vTaskDelay(1);
-  }
-  bufB = (uint8_t*)malloc(BUF_SIZE);
-  if( bufB == NULL ) {
-    log_e("Panic! Can't malloc %d bytes for buffer 2", BUF_SIZE );
-    while(1) vTaskDelay(1);
-  }
 
 }
+
+
+bool Buffer::init() {
+  bufA = (uint8_t*)EWH_MALLOC(BUF_SIZE);
+  if( bufA == NULL ) {
+    log_e("Panic! Can't malloc %d bytes for buffer 1", BUF_SIZE );
+    return false;
+  }
+  bufB = (uint8_t*)EWH_MALLOC(BUF_SIZE);
+  if( bufB == NULL ) {
+    log_e("Panic! Can't malloc %d bytes for buffer 2", BUF_SIZE );
+    return false;
+  }
+  return true;
+}
+
+
 
 void Buffer::checkFS(fs::FS* fs) {
   if( !fs->exists( folderName ) ) {

--- a/ESP32-WiFi-Hash-Monster/Buffer.cpp
+++ b/ESP32-WiFi-Hash-Monster/Buffer.cpp
@@ -1,8 +1,17 @@
 #include "Buffer.h"
 
-Buffer::Buffer(){
+Buffer::Buffer() {
   bufA = (uint8_t*)malloc(BUF_SIZE);
+  if( bufA == NULL ) {
+    log_e("Panic! Can't malloc %d bytes for buffer 1", BUF_SIZE );
+    while(1) vTaskDelay(1);
+  }
   bufB = (uint8_t*)malloc(BUF_SIZE);
+  if( bufB == NULL ) {
+    log_e("Panic! Can't malloc %d bytes for buffer 2", BUF_SIZE );
+    while(1) vTaskDelay(1);
+  }
+
 }
 
 void Buffer::checkFS(fs::FS* fs) {
@@ -25,13 +34,14 @@ bool Buffer::open(fs::FS* fs){
     }
   } while(fs->exists( fileNameStr ));
 
-  Serial.println( fileNameStr );
+  Serial.printf( "Will create new file: %s\n", fileNameStr );
 
   file = fs->open( fileNameStr, FILE_WRITE);
   file.close();
 
   if( !fs->exists( fileNameStr ) ) {
     // SD Card full or not inserted
+    log_e("SD Card full or not inserted");
     return false;
   }
 
@@ -56,7 +66,7 @@ void Buffer::close(fs::FS* fs){
   if(!writing) return;
   forceSave(fs);
   writing = false;
-  Serial.println("file closed");
+  Serial.printf( "File: %s closed\n", fileNameStr );
 }
 
 uint64_t Buffer::micros64() {
@@ -147,7 +157,7 @@ void Buffer::save(fs::FS* fs){
   uint32_t startTime = millis();
   uint32_t finishTime;
 
-  file = fs->open( fileNameStr, FILE_APPEND);
+  file = fs->open( fileNameStr, FILE_APPEND );
   if (!file) {
     Serial.printf("Failed to open file %s\n", fileNameStr );
     useSD = false;

--- a/ESP32-WiFi-Hash-Monster/Buffer.h
+++ b/ESP32-WiFi-Hash-Monster/Buffer.h
@@ -7,8 +7,14 @@
 
 #if defined ARDUINO_M5Stack_Core_ESP32
   #define BUF_BLOCKS 4
+  #define EWH_MALLOC malloc
 #else
   #define BUF_BLOCKS 24
+  #if defined BOARD_HAS_PSRAM
+    #define EWH_MALLOC ps_malloc
+  #else
+    #define EWH_MALLOC malloc
+  #endif
 #endif
 
 #define BUF_SIZE BUF_BLOCKS * 1024
@@ -19,6 +25,7 @@ extern bool useSD;
 class Buffer {
   public:
     Buffer();
+    bool init();
     void checkFS(fs::FS* fs);
     bool open(fs::FS* fs);
     void close(fs::FS* fs);

--- a/ESP32-WiFi-Hash-Monster/Buffer.h
+++ b/ESP32-WiFi-Hash-Monster/Buffer.h
@@ -5,7 +5,13 @@
 #include "FS.h"
 //#include "SD_MMC.h"
 
-#define BUF_SIZE 24 * 1024
+#if defined ARDUINO_M5Stack_Core_ESP32
+  #define BUF_BLOCKS 4
+#else
+  #define BUF_BLOCKS 24
+#endif
+
+#define BUF_SIZE BUF_BLOCKS * 1024
 #define SNAP_LEN 2324 // max len of each recieved packet
 
 extern bool useSD;

--- a/ESP32-WiFi-Hash-Monster/ESP32-WiFi-Hash-Monster.ino
+++ b/ESP32-WiFi-Hash-Monster/ESP32-WiFi-Hash-Monster.ino
@@ -23,18 +23,16 @@
 // Button : click to change channel hold to dis/enable SD
 // SD : GPIO4=CS(CD/D3), 23=MOSI(CMD), 18=CLK, 19=MISO(D0)
 //--------------------------------------------------------------------
-#ifdef ARDUINO_M5STACK_Core2
+#if defined (ARDUINO_M5STACK_Core2)
   #include <M5Core2.h>        // https://github.com/m5stack/M5Core2/
-#endif
-#if defined(ARDUINO_M5STACK_FIRE) || defined(ARDUINO_M5Stack_Core_ESP32)
-  #include <M5Stack.h>        // https://github.com/m5stack/M5Stack/    (use version => 0.3.0 to properly display the Monster)
-#endif
-#ifdef ARDUINO_ODROID_ESP32
+//#elif defined(ARDUINO_M5STACK_FIRE) || defined(ARDUINO_M5Stack_Core_ESP32)
+//  #include <M5Stack.h>        // https://github.com/m5stack/M5Stack/    (use version => 0.3.0 to properly display the Monster)
+#elif defined (ARDUINO_ODROID_ESP32) || defined(ARDUINO_M5STACK_FIRE) || defined(ARDUINO_M5Stack_Core_ESP32)
   #include <ESP32-Chimera-Core.h>        // https://github.com/tobozo/ESP32-Chimera-Core/
 #endif
 
 #ifdef USE_M5STACK_UPDATER
-#include <M5StackUpdater.h> // https://github.com/tobozo/M5Stack-SD-Updater/
+  #include <M5StackUpdater.h> // https://github.com/tobozo/M5Stack-SD-Updater/
 #endif
 #include "Free_Fonts.h"
 #include <SPI.h>
@@ -81,6 +79,7 @@ esp_err_t event_handler(void* ctx,system_event_t* event){return ESP_OK;}
 Buffer sdBuffer;
 Preferences preferences;
 bool useSD = USE_SD_BY_DEFAULT;
+static bool SDSetupDone = false;
 
 uint32_t lastDrawTime = 0;
 uint32_t lastButtonTime = millis();
@@ -187,7 +186,7 @@ void setup() {
   M5.begin(); // this will fire Serial.begin()
   #ifdef USE_M5STACK_UPDATER
   // New SD Updater support, requires the latest version of https://github.com/tobozo/M5Stack-SD-Updater/
-  checkSDUpdater( /*SD, MENU_BIN, 1500*/ ); // Filesystem, Launcher bin path, Wait delay
+  checkSDUpdater( SD, MENU_BIN, 1500, TFCARD_CS_PIN ); // Filesystem, Launcher bin path, Wait delay
   #endif
   // SD card ---------------------------------------------------------
   bool toggle = false;
@@ -210,6 +209,8 @@ void setup() {
       #endif
     }
   }
+
+  SDSetupDone = true;
 
   // Settings
   preferences.begin("packetmonitor32", false);
@@ -435,7 +436,7 @@ void smartSwitchChannel(uint32_t currentTime) {
 
 // ===== functions ===================================================
 
-static bool SDSetupDone = false;
+
 
 bool setupSD() {
   if( SDSetupDone ) return true;

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ default_envs = m5stack-fire
 ;default_envs = odroid_esp32
 
 [env]
-platform = espressif32
+platform = espressif32@2.0.0
 framework = arduino
 upload_speed = 921600
 ; deep needed in order to pick up SD.h dependency of M5Stack-SD-Updater
@@ -35,12 +35,14 @@ lib_deps =
   Update
   Preferences
   FastLED
+  ESP32-Chimera-Core
+  LovyanGFX
 
 [env:m5stack-fire]
 board = m5stack-fire
 lib_deps =
   ${env.lib_deps}
-  M5Stack
+  ;M5Stack
   M5Stack-SD-Updater
 build_flags =
   '-DUSE_M5STACK_UPDATER'
@@ -49,7 +51,7 @@ build_flags =
 board = m5stack-core-esp32
 lib_deps =
   ${env.lib_deps}
-  M5Stack
+  ;M5Stack
   M5Stack-SD-Updater
 build_flags =
   '-DUSE_M5STACK_UPDATER'

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ default_envs = m5stack-fire
 platform = espressif32@2.0.0
 framework = arduino
 upload_speed = 921600
+monitor_speed = 115200
 ; deep needed in order to pick up SD.h dependency of M5Stack-SD-Updater
 lib_ldf_mode = deep
 ; lib_extra_dirs = ~/Documents/Arduino/libraries/

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ default_envs = m5stack-fire
 ;default_envs = odroid_esp32
 
 [env]
-platform = espressif32@2.0.0
+platform = espressif32@3.3.2
 framework = arduino
 upload_speed = 921600
 monitor_speed = 115200
@@ -36,15 +36,15 @@ lib_deps =
   Update
   Preferences
   FastLED
-  ESP32-Chimera-Core
-  LovyanGFX
+  ESP32-Chimera-Core@1.1.9
+  LovyanGFX@0.4.2
+  M5Stack-SD-Updater@1.1.2
 
 [env:m5stack-fire]
+platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
 board = m5stack-fire
 lib_deps =
   ${env.lib_deps}
-  ;M5Stack
-  M5Stack-SD-Updater
 build_flags =
   '-DUSE_M5STACK_UPDATER'
 
@@ -52,21 +52,22 @@ build_flags =
 board = m5stack-core-esp32
 lib_deps =
   ${env.lib_deps}
-  ;M5Stack
-  M5Stack-SD-Updater
 build_flags =
   '-DUSE_M5STACK_UPDATER'
 
 [env:m5stack-core2]
+;platform = espressif32
+platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
 board = m5stack-core2
 lib_deps =
   ${env.lib_deps}
-  M5Core2
 lib_ignore =
-  M5Stack
+  M5Core2
+build_flags =
+  '-DUSE_M5STACK_UPDATER'
+
 
 [env:odroid_esp32]
 board = odroid_esp32
 lib_deps =
   ${env.lib_deps}
-  ESP32-Chimera-Core


### PR DESCRIPTION
### M5Stack classic
- fix for crash when secondary buffer was used
- fix for SD Card failing to load unless reinserted
### All boards
- fix for blue layout turning white: migrated to LovyanGFX+Chimera-Core 
- moved memory allocation outside `Buffer` constructor to provide late init (e.g. psram)
### Platformio configuration
- dropped M5Stack.h support
- adjusted lib_deps and platform version (using arduino core 2.0.0)
- implemented PR #28 