### PR TITLE
Fix for lib_deps not merging resolved versions in dep tree

### DIFF
--- a/.github/workflows/BuildPlatformio.yml
+++ b/.github/workflows/BuildPlatformio.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Cache pip
       uses: actions/cache@v2
       with:

--- a/.github/workflows/BuildPlatformio.yml
+++ b/.github/workflows/BuildPlatformio.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
     - name: Cache pip
       uses: actions/cache@v2
       with:
@@ -36,6 +38,6 @@ jobs:
         pip install --upgrade platformio
     - name: Run PlatformIO
       run: pio run -e m5stack-fire -e m5stack-core-esp32 -e m5stack-core2 -e odroid_esp32
-      
-          
-      
+
+
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ upload_speed = 921600
 monitor_speed = 115200
 ; deep needed in order to pick up SD.h dependency of M5Stack-SD-Updater
 lib_ldf_mode = deep
+lib_compat_mode = strict
 ; lib_extra_dirs = ~/Documents/Arduino/libraries/
 lib_deps =
   Wire
@@ -37,8 +38,8 @@ lib_deps =
   WiFiClientSecure
   Update
   Preferences
-  ESP32-Chimera-Core@1.2.2
   LovyanGFX@0.4.3
+  ESP32-Chimera-Core@1.2.2
   M5Stack-SD-Updater@1.1.3
 
 [env:m5stack-fire]

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,7 @@ lib_deps =
   Update
   Preferences
   LovyanGFX@0.4.3
-  ESP32-Chimera-Core@1.2.2
+  ESP32-Chimera-Core@1.2.4
   M5Stack-SD-Updater@1.1.3
 
 [env:m5stack-fire]


### PR DESCRIPTION
An automated build started to fail after LovyanGFX latest version was raised (0.4.3 => 0.4.4).

Apparently platformio would download two different versions of the LovyanGFX library and throw duplicate declaration errors at compilation. This didn't happen before because the version in plaformio.ini was equal to the latest version on the repository.

- One version of LovyanGFX is a dependency of ESP32-Chimera-Core which comes with a `library.json` file where the version of LovyanGFX is unspecified (was resolving as <0.4.4>).
- The other version is hardcoded in the platformio.ini as <0.4.3>, that's the one we want because we know it's working with this project along with other specific library versions.

Changing the library order in `lib_deps` fixed it, platformio is now resolving LovyanGFX to a single version as expected.
