### PR TITLE
Updated random() call to include min and max inputs. Was causing

### DIFF
--- a/ESP32-WiFi-Hash-Monster/ESP32-WiFi-Hash-Monster.ino
+++ b/ESP32-WiFi-Hash-Monster/ESP32-WiFi-Hash-Monster.ino
@@ -503,7 +503,7 @@ static void bootAnimationTask( void* param )
     if(  (xdir == 1  && xpos+xdir >= tft.width()-64)
       || (xdir == -1 && xpos+xdir < 0 ) ) {
       xdir = -xdir;
-      imgId = random()%13;
+      imgId = random(0,13);
     }
     xpos += xdir*hstep;
     vcursor += vstep;


### PR DESCRIPTION
a random() not found error when compiling with arduino.